### PR TITLE
Remove pull request limit

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "active-pull-requests",
     "publisher": "karlingen",
-    "version": "1.0.29",
+    "version": "1.0.30",
     "name": "Active Pull Requests",
     "description": "Azure DevOps Extension",
     "categories": [

--- a/src/Samples/ActivePullRequests/PullRequestsListingPageContent.tsx
+++ b/src/Samples/ActivePullRequests/PullRequestsListingPageContent.tsx
@@ -93,7 +93,12 @@ class PullRequestsListingPageContent extends React.Component<IPullRequestsListin
             sourceRepositoryId: "",
             status: PullRequestStatus.Active,
             targetRefName: ""
-        });
+        },
+            undefined,
+            undefined,
+            // Top should be set to '0' to retrieve all repositories. Otherwise, there will be a limit of 100 items.
+            // We should revisit this when/if this will cause performance issues in the future.
+            0);
 
         if (pullRequests && pullRequests.length > 0) {
             this.setState({


### PR DESCRIPTION
If there are more than 100 active pull requests, some of them aren't displayed due to the behavior of `getPullRequestsByProject`. 
We need to tell it to not limit the results and return all pull requests.
