### PR TITLE
Use Graph Avatars API when fetching user images (Fix #16)

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -37,7 +37,8 @@
         }
     },
     "scopes": [
-        "vso.code"
+        "vso.code",
+        "vso.graph"
     ],
     "files": [
         {

--- a/configs/dev.json
+++ b/configs/dev.json
@@ -1,5 +1,5 @@
 {
     "id": "active-pull-requests-dev", 
     "public": false,
-    "baseUri": "https://0.0.0.0:3000" 
+    "baseUri": "https://127.0.0.1:3000"
 }


### PR DESCRIPTION
Fetch user images using the [Graph Avatars API](https://learn.microsoft.com/en-us/rest/api/azure/devops/graph/avatars/get?view=azure-devops-rest-7.2) to fix images not loading in Firefox

This fixes #16 